### PR TITLE
Replaced source of request identifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.3](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.1.3)
+July 31 2018
+
+#### Updated
+- `taskIdentifier` replaced with `NSUUID`.
+  - Updated by [parfeon](https://github.com/parfeon) in Pull Request [#3](https://github.com/parfeon/YAHTTPVCR/pull/3).
+
 ## [1.1.2](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.1.2)
 July 31 2018
 

--- a/YAHTTPVCR.podspec
+++ b/YAHTTPVCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'YAHTTPVCR'
-    spec.version  = '1.1.2'
+    spec.version  = '1.1.3'
     spec.summary  = 'Yet Another HTTP VCR.'
     spec.homepage = 'https://github.com/parfeon/YAHTTPVCR'
     spec.documentation_url = 'https://github.com/parfeon/YAHTTPVCR/wiki'

--- a/YAHTTPVCR/Core/YHVCassette.m
+++ b/YAHTTPVCR/Core/YHVCassette.m
@@ -637,8 +637,6 @@
 
 - (void)beginRecordingTask:(NSURLSessionTask *)task {
 
-    task.originalRequest.YHV_identifier = @(task.taskIdentifier).stringValue;
-
     [self beginRecordingRequest:task.originalRequest];
 }
 


### PR DESCRIPTION
Looks like NSURLSession re-use identifiers for task in very short interval. 
This update changes identifier generation to `NSUUID`.  