### PR TITLE
'postBodyFilter' block signature update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.0](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.0)
+July 31 2018
+
+#### Updated
+- `postBodyFilter` now accept body parameter which will pass body from request or it's stub.
+  - Updated by [parfeon](https://github.com/parfeon) in Pull Request [#4](https://github.com/parfeon/YAHTTPVCR/pull/4).
+
 ## [1.1.3](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.1.3)
 July 31 2018
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ configuration.postBodyFilter = @{ @"fullName": [NSNull null], @"pwd": @"pwd" };
  * In example below, we replace 'sender:alex' string in POST body with 
  * 'sender:bob' which will be part of stored stub.
  */
-configuration.postBodyFilter = ^NSData * (NSURLRequest *request) {
-    NSString *message = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
+configuration.postBodyFilter = ^NSData * (NSURLRequest *request, NSData *body) {
+    NSString *message = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
     message = [request.URI.path stringByReplacingOccurrencesOfString:@"sender:alex" withString:@"sender:bob"];
 
     return [message dataUsingEncoding:NSUTF8StringEncoding];

--- a/Tests/Fixtures/YHVCassettePlaybackIntegerationTest.bundle/NSURLSessionPlaybackPOSTShouldPassStubbedPOSTDataToBodyFilter.json
+++ b/Tests/Fixtures/YHVCassettePlaybackIntegerationTest.bundle/NSURLSessionPlaybackPOSTShouldPassStubbedPOSTDataToBodyFilter.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id" : "96C03C86-DC32-46B0-BF70-E52A2B45489F",
+    "data" : {
+      "method" : "post",
+      "cls" : "NSURLRequest",
+      "cellular" : true,
+      "network" : 0,
+      "cache" : 0,
+      "timeout" : 60,
+      "cookies" : true,
+      "headers" : {
+        "User-Agent" : "YHVVCR2",
+        "Content-Type" : "application\/json",
+        "Authorization" : "Basic secret-authorization-value"
+      },
+      "body" : {
+        "cls" : "NSData",
+        "base64" : "eyJwb3N0Qm9keUZpZWxkMiI6InBvc3RCb2R5VmFsdWUyIiwicG9zdEJvZHlGaWVsZDEiOiJzZWNyZXQtcG9zdC1ib2R5LXZhbHVlIn0="
+      },
+      "pipeline" : false,
+      "url" : "https:\/\/httpbin.org\/post"
+    },
+    "type" : 0
+  },
+  {
+    "id" : "96C03C86-DC32-46B0-BF70-E52A2B45489F",
+    "data" : {
+      "status" : 200,
+      "cls" : "NSHTTPURLResponse",
+      "url" : "https:\/\/httpbin.org\/post",
+      "headers" : {
+        "Access-Control-Allow-Credentials" : "true",
+        "Content-Type" : "application\/json",
+        "Server" : "gunicorn\/19.9.0",
+        "Via" : "1.1 vegur",
+        "Access-Control-Allow-Origin" : "*",
+        "Date" : "Sun, 29 Jul 2018 22:45:59 GMT",
+        "Content-Length" : "746",
+        "Connection" : "keep-alive"
+      }
+    },
+    "type" : 1
+  },
+  {
+    "id" : "96C03C86-DC32-46B0-BF70-E52A2B45489F",
+    "data" : {
+      "cls" : "NSData",
+      "base64" : "eyJwb3N0Qm9keUZpZWxkMiI6InBvc3RCb2R5VmFsdWUyIiwicG9zdEJvZHlGaWVsZDEiOiJzZWNyZXQtcG9zdC1ib2R5LXZhbHVlIn0="
+    },
+    "type" : 2
+  },
+  {
+    "id" : "96C03C86-DC32-46B0-BF70-E52A2B45489F",
+    "type" : 4
+  }
+]

--- a/Tests/Helpers/YHVIntegrationTestCase.h
+++ b/Tests/Helpers/YHVIntegrationTestCase.h
@@ -16,6 +16,7 @@ typedef void(^YHVVerificationBlock)(NSURLRequest *request, NSHTTPURLResponse * _
 #pragma mark - Information
 
 @property (nonatomic, readonly, copy) NSString *queryString;
+@property (nonatomic, readonly, copy) NSDictionary *filteredPOSTBody;
 
 
 #pragma mark - Request configuration

--- a/Tests/Helpers/YHVIntegrationTestCase.m
+++ b/Tests/Helpers/YHVIntegrationTestCase.m
@@ -59,6 +59,14 @@
 @implementation YHVIntegrationTestCase
 
 
+#pragma mark - Information
+
+- (NSDictionary *)filteredPOSTBody {
+    
+    return self.expectedPostBody;
+}
+
+
 #pragma mark - Configuration
 
 - (void)updateVCRConfigurationFromDefaultConfiguration:(YHVConfiguration *)configuration {

--- a/Tests/Integration/YHVCassettePlaybackIntegerationTest.m
+++ b/Tests/Integration/YHVCassettePlaybackIntegerationTest.m
@@ -45,6 +45,14 @@
             return request;
         };
     }
+    
+    if ([self.name rangeOfString:@"POSTDataToBodyFilter"].location != NSNotFound) {
+        configuration.postBodyFilter = ^NSData * (NSURLRequest *request, NSData *body) {
+            XCTAssertNotNil(body);
+            
+            return [NSJSONSerialization dataWithJSONObject:[self filteredPOSTBody] options:(NSJSONWritingOptions)0 error:nil];
+        };
+    }
 }
 
 
@@ -277,6 +285,17 @@
 #pragma mark - Tests :: Playback :: NSURLSession :: POST
 
 - (void)testNSURLSessionPlaybackPOST_ShouldReturnStubbedResponse {
+    
+    NSURLRequest *targetRequest = [self POSTRequestWithPath:@"/post"];
+    
+    [self NSURLSessionSendRequest:targetRequest
+      withResultVerificationBlock:^(NSURLRequest *request, NSHTTPURLResponse *response, NSData *data, NSError *error) {
+          
+          [self assertResponse:response playedForRequest:request withData:data];
+      }];
+}
+
+- (void)testNSURLSessionPlaybackPOST_ShouldPassStubbedPOSTDataToBodyFilter {
     
     NSURLRequest *targetRequest = [self POSTRequestWithPath:@"/post"];
     

--- a/Tests/Unit/Core/YHVVCRTest.m
+++ b/Tests/Unit/Core/YHVVCRTest.m
@@ -511,7 +511,7 @@
     }];
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
-    NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request);
+    NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     NSDictionary *jsonData = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
     XCTAssertNotNil(data);
     XCTAssertNotEqualObjects(data, request.HTTPBody);
@@ -532,7 +532,7 @@
     }];
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
-    NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request);
+    NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     NSString *postBodyString = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] stringByReplacingOccurrencesOfString:@"+" withString:@" "];
     NSDictionary *dataDictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString];
     XCTAssertNotNil(data);
@@ -554,7 +554,7 @@
     }];
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
-    NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request);
+    NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     XCTAssertEqualObjects(data, request.HTTPBody);
 }
 
@@ -576,7 +576,7 @@
     }];
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
-    ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request);
+    ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     XCTAssertFalse(bodyFilterBlockCalled);
 }
 
@@ -597,7 +597,7 @@
     }];
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
-    ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request);
+    ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     XCTAssertTrue(bodyFilterBlockCalled);
 }
 
@@ -625,7 +625,7 @@
         };
     }];
     
-    ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request);
+    ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     XCTAssertTrue(cassetteBodyFilterBlockCalled);
     XCTAssertFalse(vcrBodyFilterBlockCalled);
 }

--- a/YAHTTPVCR.podspec
+++ b/YAHTTPVCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'YAHTTPVCR'
-    spec.version  = '1.1.3'
+    spec.version  = '1.2.0'
     spec.summary  = 'Yet Another HTTP VCR.'
     spec.homepage = 'https://github.com/parfeon/YAHTTPVCR'
     spec.documentation_url = 'https://github.com/parfeon/YAHTTPVCR/wiki'

--- a/YAHTTPVCR/Core/YHVVCR.m
+++ b/YAHTTPVCR/Core/YHVVCR.m
@@ -513,7 +513,7 @@ NS_ASSUME_NONNULL_END
         finalRequest.URL = configuration.urlFilter(finalRequest, finalRequest.URL);
         
         if (configuration.postBodyFilter) {
-            finalRequest.HTTPBody = ((YHVPostBodyFilterBlock)configuration.postBodyFilter)(finalRequest);
+            finalRequest.HTTPBody = ((YHVPostBodyFilterBlock)configuration.postBodyFilter)(finalRequest, finalRequest.YHV_HTTPBody);
         }
         
         NSURLRequest *updatedRequest = beforeRecordRequest ? beforeRecordRequest(finalRequest) : finalRequest;
@@ -648,17 +648,17 @@ NS_ASSUME_NONNULL_END
         bodyKeysForModification = [postBodyFilter copy];
     }
     
-    return ^NSData * (NSURLRequest *request) {
+    return ^NSData * (NSURLRequest *request, NSData *body) {
         if (![request.HTTPMethod.lowercaseString isEqualToString:@"post"]) {
-            return request.HTTPBody;
+            return body;
         } else if (postBodyFilter && !bodyKeysForModification) {
-            return ((YHVPostBodyFilterBlock)postBodyFilter)(request);
+            return ((YHVPostBodyFilterBlock)postBodyFilter)(request, body);
         }
         
         NSMutableDictionary *keyValue = [[NSDictionary YHV_dictionaryFromNSURLRequestPOSTBody:request] mutableCopy];
         
         if (!keyValue) {
-            return request.HTTPBody;
+            return body;
         }
         
         return [[keyValue YHV_replaceValuesWithValuesFromDictionary:bodyKeysForModification] YHV_POSTBodyForNSURLRequest:request];

--- a/YAHTTPVCR/Misc/YHVStructures.h
+++ b/YAHTTPVCR/Misc/YHVStructures.h
@@ -2,7 +2,7 @@
  * @brief Set of types and structures which is used by VCR and it's components.
  *
  * @author Serhii Mamontov
- * @version 1.0.0
+ * @since 1.0.0
  */
 #ifndef YHVStructures_h
 #define YHVStructures_h
@@ -163,10 +163,13 @@ typedef void(^YHVHeadersFilterBlock)(NSURLRequest *request, NSMutableDictionary 
  * @brief Request POST body filter block.
  *
  * @param request Reference on request for which POST body filtering has been performed.
+ * @param body    Reference on data which should be filtered.
  *
  * @return Reference on value which should be used instead of original one or \c nil in case if POST body should be removed.
+ *
+ * @since 1.2.0
  */
-typedef NSData * __nullable (^YHVPostBodyFilterBlock)(NSURLRequest *request);
+typedef NSData * __nullable (^YHVPostBodyFilterBlock)(NSURLRequest *request, NSData * __nullable body);
 
 /**
  * @brief Response body filter block.


### PR DESCRIPTION
Block signature and usage has been updated, because when VCR plays stubbed data, HTTP post body at the moment of block call already sent to HTTP post body stream and `nullified`.  
Update allows to get content which has been sent to body stream and work with it.