### PR TITLE
VCR set stubbed response handler fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.1](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.1)
+August 1 2018
+
+#### Fixed
+- Fixed set response VCR handler.
+  - Fixed by [parfeon](https://github.com/parfeon) in Pull Request [#5](https://github.com/parfeon/YAHTTPVCR/pull/5).
+
 ## [1.2.0](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.0)
 July 31 2018
 

--- a/YAHTTPVCR.podspec
+++ b/YAHTTPVCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'YAHTTPVCR'
-    spec.version  = '1.2.0'
+    spec.version  = '1.2.1'
     spec.summary  = 'Yet Another HTTP VCR.'
     spec.homepage = 'https://github.com/parfeon/YAHTTPVCR'
     spec.documentation_url = 'https://github.com/parfeon/YAHTTPVCR/wiki'

--- a/YAHTTPVCR/Misc/Categories/NSURLSessionConnection+YHVRecorder.m
+++ b/YAHTTPVCR/Misc/Categories/NSURLSessionConnection+YHVRecorder.m
@@ -3,6 +3,7 @@
  * @since 1.0.0
  */
 #import "NSURLSessionConnection+YHVRecorder.h"
+#import "NSHTTPURLResponse+YHVMisc.h"
 #import "NSURLRequest+YHVPlayer.h"
 #import "YHVMethodsSwizzler.h"
 #import "YHVVCR+Recorder.h"
@@ -27,6 +28,7 @@
 
 - (id)YHV_initWithTask:(id)arg1 delegate:(id)arg2 delegateQueue:(id)arg3;
 - (void)YHV__redirectRequest:(id)request redirectResponse:(id)response completion:(id)block;
+- (void)YHV__didReceiveResponse:(NSURLResponse *)response sniff:(BOOL)sniff;
 - (void)YHV__didReceiveData:(id)data;
 
 #pragma mark -
@@ -74,6 +76,19 @@
     [YHVVCR clearFetchedDataForTask:self.task];
     
     [self YHV__redirectRequest:request redirectResponse:response completion:block];
+}
+
+- (void)YHV__didReceiveResponse:(NSURLResponse *)response sniff:(BOOL)sniff {
+
+    if (self.task.originalRequest.YHV_cassetteChapterIdentifier || self.task.currentRequest.YHV_cassetteChapterIdentifier) {
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            response = [(NSHTTPURLResponse *)response YHV_responseForRequest:self.task.originalRequest];
+        }
+        
+        [YHVVCR handleResponsePlayedForTask:self.task];
+    }
+    
+    [self YHV__didReceiveResponse:response sniff:sniff];
 }
 
 - (void)YHV__didReceiveData:(id)data {

--- a/YAHTTPVCR/Misc/Categories/NSURLSessionTask+YHVRecorder.m
+++ b/YAHTTPVCR/Misc/Categories/NSURLSessionTask+YHVRecorder.m
@@ -62,13 +62,11 @@
     
     NSURLSessionTask *task = (NSURLSessionTask *)self;
     
-    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-        response = [response YHV_responseForRequest:task.originalRequest];
-    }
-    
-    if (task.originalRequest.YHV_cassetteChapterIdentifier || task.currentRequest.YHV_cassetteChapterIdentifier) {
-        [YHVVCR handleResponsePlayedForTask:task];
-    } else {
+    if (!task.originalRequest.YHV_cassetteChapterIdentifier && !task.currentRequest.YHV_cassetteChapterIdentifier) {
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            response = [response YHV_responseForRequest:task.originalRequest];
+        }
+        
         [YHVVCR recordResponse:response forTask:task];
     }
     


### PR DESCRIPTION
When cassette is playing, there is step of response setting. `setResponse` in `NSURLSessionTask` not get called for certain responses (those, for which `Content-Type` is something other than `application/json`).
With this fix, response setting handler has been moved from `NSURLSessionTask` to `NSURLSessionConnection`.