### PR TITLE
Fixed empty response body playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.2](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.2)
+August 1 2018
+
+#### Fixed
+- Fixed empty response body playback.
+  - Fixed by [parfeon](https://github.com/parfeon) in Pull Request [#6](https://github.com/parfeon/YAHTTPVCR/pull/6).
+
 ## [1.2.1](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.1)
 August 1 2018
 

--- a/Tests/Fixtures/YHVCassettePlaybackIntegerationTest.bundle/NSURLSessionPlaybackGETShouldReturnStubbedResponseWhenStubRecordedWithEmptyData.json
+++ b/Tests/Fixtures/YHVCassettePlaybackIntegerationTest.bundle/NSURLSessionPlaybackGETShouldReturnStubbedResponseWhenStubRecordedWithEmptyData.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id" : "B5638C72-A2C6-4A95-9E9D-BDEDA9BF0009",
+    "data" : {
+      "method" : "get",
+      "cls" : "NSURLRequest",
+      "cellular" : true,
+      "cache" : 0,
+      "timeout" : 1,
+      "cookies" : true,
+      "headers" : {
+        "User-Agent" : "YHVVCR2",
+        "Content-Type" : "application\/json",
+        "Authorization" : "Basic secret-authorization-value"
+      },
+      "pipeline" : false,
+      "network" : 0,
+      "url" : "https:\/\/httpbin.org\/get?queryField3=queryValue3&queryField1=secret-query-value"
+    },
+    "type" : 0
+  },
+  {
+    "id" : "B5638C72-A2C6-4A95-9E9D-BDEDA9BF0009",
+    "data" : {
+      "status" : 200,
+      "cls" : "NSHTTPURLResponse",
+      "url" : "https:\/\/httpbin.org\/get?queryField3=queryValue3&queryField1=secret-query-value",
+      "headers" : {
+        "Access-Control-Allow-Credentials" : "true",
+        "Content-Type" : "application\/json",
+        "Server" : "gunicorn\/19.9.0",
+        "Via" : "1.1 vegur",
+        "Access-Control-Allow-Origin" : "*",
+        "Date" : "Tue, 31 Jul 2018 22:15:19 GMT",
+        "Content-Length" : "0",
+        "Connection" : "keep-alive"
+      }
+    },
+    "type" : 1
+  },
+  {
+    "id" : "B5638C72-A2C6-4A95-9E9D-BDEDA9BF0009",
+    "data" : {
+      "cls" : "NSData",
+      "base64" : ""
+    },
+    "type" : 2
+  },
+  {
+    "id" : "B5638C72-A2C6-4A95-9E9D-BDEDA9BF0009",
+    "type" : 4
+  }
+]

--- a/Tests/Integration/YHVCassettePlaybackIntegerationTest.m
+++ b/Tests/Integration/YHVCassettePlaybackIntegerationTest.m
@@ -65,6 +65,18 @@
     [self NSURLSessionSendRequest:targetRequest
       withResultVerificationBlock:^(NSURLRequest *request, NSHTTPURLResponse *response, NSData *data, NSError *error) {
           
+          [self assertResponse:response playedForRequest:request withData:data];
+      }];
+}
+
+- (void)testNSURLSessionPlaybackGET_ShouldReturnStubbedResponse_WhenStubRecordedWithEmptyData {
+    
+    NSMutableURLRequest *targetRequest = [[self GETRequestWithPath:@"/get"] mutableCopy];
+    targetRequest.timeoutInterval = 1.f;
+    
+    [self NSURLSessionSendRequest:targetRequest
+      withResultVerificationBlock:^(NSURLRequest *request, NSHTTPURLResponse *response, NSData *data, NSError *error) {
+          
         [self assertResponse:response playedForRequest:request withData:data];
     }];
 }

--- a/YAHTTPVCR.podspec
+++ b/YAHTTPVCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'YAHTTPVCR'
-    spec.version  = '1.2.1'
+    spec.version  = '1.2.2'
     spec.summary  = 'Yet Another HTTP VCR.'
     spec.homepage = 'https://github.com/parfeon/YAHTTPVCR'
     spec.documentation_url = 'https://github.com/parfeon/YAHTTPVCR/wiki'

--- a/YAHTTPVCR/Core/YHVCassette.m
+++ b/YAHTTPVCR/Core/YHVCassette.m
@@ -475,9 +475,13 @@
                 [self handleResponsePlayedForRequest:protocol.request];
             }
         } else if (scene.type == YHVDataScene) {
-            [protocol.client URLProtocol:protocol didLoadData:(id)scene.data];
+            NSData *data = (id)scene.data;
             
-            if ([self.connectionChapterIdentifiers containsObject:chapterIdentifier]) {
+            if (data.length) {
+                [protocol.client URLProtocol:protocol didLoadData:data];
+            }
+            
+            if (!data.length || [self.connectionChapterIdentifiers containsObject:chapterIdentifier]) {
                 [self handleDataPlayedForRequest:protocol.request];
             }
         } else if (scene.type == YHVErrorScene) {


### PR DESCRIPTION
Looks like NSURLProtocol clients doesn't like when empty data is sent to them with `-URLProtocol:didLoadData:` and process stops (no feedback about data consumption).  
With fix, when response body stub should be played, it checks first whether there is some binary data in it. If stub doesn't have response data, it marked as played and playback continues.