### PR TITLE
NSDictionary category query string generation fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.3](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.3)
+August 1 2018
+
+#### Fixed
+- Fixed `NSDictionary` category for query string generation.
+  - Fixed by [parfeon](https://github.com/parfeon) in Pull Request [#7](https://github.com/parfeon/YAHTTPVCR/pull/7).
+
 ## [1.2.2](https://github.com/parfeon/YAHTTPVCR/releases/tag/v1.2.2)
 August 1 2018
 

--- a/Tests/Unit/Misc/Categories/NSDictionaryCategoryTest.m
+++ b/Tests/Unit/Misc/Categories/NSDictionaryCategoryTest.m
@@ -45,7 +45,7 @@
     [super setUp];
     
     NSCharacterSet *charSet = [NSCharacterSet URLQueryAllowedCharacterSet];
-    self.regularQueryString = @"test1=value1&test2=value2&test3=value3";
+    self.regularQueryString = @"test1=value1&test2=value2&test3=3";
     self.queryStringWithMissingValue = @"test1=value1&test2=&test3=value3";
     self.queryStringWithMissingEqualSign = @"test1=value1&test2=value2&test3";
     self.queryStringWithJSONStringValue = @"test1=value1&test2={\"title\":\"yet another http vcr\"}&test3=value3";
@@ -57,7 +57,7 @@
     self.queryStringWithJSONStringValue = [self.queryStringWithJSONStringValue stringByAddingPercentEncodingWithAllowedCharacters:charSet];
     self.wwwFormURLEncodedString = [self.wwwFormURLEncodedString stringByAddingPercentEncodingWithAllowedCharacters:charSet];
     
-    self.expectedForRegularQuery = @{ @"test1": @"value1", @"test2": @"value2", @"test3": @"value3" };
+    self.expectedForRegularQuery = @{ @"test1": @"value1", @"test2": @"value2", @"test3": @3 };
     self.expectedForQueryWithMissingValue = @{ @"test1": @"value1", @"test3": @"value3" };
     self.expectedForQueryWithMissingEqualSign = @{ @"test1": @"value1", @"test2": @"value2" };
     self.expectedForQueryWithJSONStringValue = @{ @"test1": @"value1", @"test2": @{ @"title" : @"yet another http vcr" }, @"test3": @"value3" };

--- a/YAHTTPVCR.podspec
+++ b/YAHTTPVCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'YAHTTPVCR'
-    spec.version  = '1.2.2'
+    spec.version  = '1.2.3'
     spec.summary  = 'Yet Another HTTP VCR.'
     spec.homepage = 'https://github.com/parfeon/YAHTTPVCR'
     spec.documentation_url = 'https://github.com/parfeon/YAHTTPVCR/wiki'

--- a/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURL.m
+++ b/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURL.m
@@ -61,7 +61,10 @@
                 value = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
             }
         }
-        value = [value stringByAddingPercentEncodingWithAllowedCharacters:charSet];
+        
+        if ([value isKindOfClass:[NSString class]]) {
+            value = [value stringByAddingPercentEncodingWithAllowedCharacters:charSet];
+        }
         
         [keyValuePairs addObject:[@[key, @"=", value] componentsJoinedByString:@""]];
     }


### PR DESCRIPTION
Pull fixes issue with `NSDictionary` category for query string generation.  
When query string decomposed with this category, it uses `NSJSONSerialization` to parse value and string with numbers will be converted to `NSNumber` instances. Query generator code didn't expected this and tried to manipulate with values as `NSString` instances.