### PR TITLE
Fix query parameters comparison

### DIFF
--- a/Tests/Helpers/YHVIntegrationTestCase.h
+++ b/Tests/Helpers/YHVIntegrationTestCase.h
@@ -1,6 +1,8 @@
 #import <YAHTTPVCR/YAHTTPVCR.h>
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark Structures
 
 /**
@@ -152,3 +154,5 @@ typedef void(^YHVVerificationBlock)(NSURLRequest *request, NSHTTPURLResponse * _
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/Unit/Core/YHVVCRTest.m
+++ b/Tests/Unit/Core/YHVVCRTest.m
@@ -535,7 +535,7 @@
     
     NSData *data = ((YHVPostBodyFilterBlock)YHVVCR.cassette.configuration.postBodyFilter)(request, request.HTTPBody);
     NSString *postBodyString = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-    NSDictionary *dataDictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString];
+    NSDictionary *dataDictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString sortQueryListOnMatch:NO];
     XCTAssertNotNil(data);
     XCTAssertNotEqualObjects(data, request.HTTPBody);
     XCTAssertEqualObjects(dataDictionary[@"field1"], @"secret-body-value");
@@ -672,7 +672,7 @@
     
     NSData *data = ((YHVResponseBodyFilterBlock)YHVVCR.cassette.configuration.responseBodyFilter)(request, response, responseData);
     NSString *postBodyString = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-    NSDictionary *dataDictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString];
+    NSDictionary *dataDictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString sortQueryListOnMatch:NO];
     XCTAssertNotNil(data);
     XCTAssertNotEqualObjects(data, responseData);
     XCTAssertEqualObjects(dataDictionary[@"field1"], @"secret-body-value");
@@ -784,7 +784,8 @@
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
     NSURLRequest *finalRequest = YHVVCR.cassette.configuration.beforeRecordRequest(request);
-    XCTAssertEqualObjects([NSDictionary YHV_dictionaryWithQuery:finalRequest.URL.query], expectedQuery);
+    XCTAssertEqualObjects([NSDictionary YHV_dictionaryWithQuery:finalRequest.URL.query sortQueryListOnMatch:NO],
+                          expectedQuery);
     XCTAssertEqualObjects(finalRequest.allHTTPHeaderFields, expectedHeaders);
     XCTAssertEqualObjects([NSJSONSerialization JSONObjectWithData:finalRequest.HTTPBody options:NSJSONReadingAllowFragments error:nil], expectedPostBody);
     XCTAssertEqualObjects(finalRequest.HTTPMethod.lowercaseString, @"get");
@@ -875,7 +876,8 @@
     [YHVVCR insertCassetteWithPath:[NSUUID UUID].UUIDString];
     
     NSArray *responseData = YHVVCR.cassette.configuration.beforeRecordResponse(request, response, data);
-    XCTAssertEqualObjects([NSDictionary YHV_dictionaryWithQuery:((NSHTTPURLResponse *)responseData.firstObject).URL.query], expectedQuery);
+    XCTAssertEqualObjects([NSDictionary YHV_dictionaryWithQuery:((NSHTTPURLResponse *)responseData.firstObject).URL.query sortQueryListOnMatch:NO],
+                          expectedQuery);
     XCTAssertEqualObjects([NSJSONSerialization JSONObjectWithData:responseData.lastObject options:NSJSONReadingAllowFragments error:nil], expectedResponseBody);
     XCTAssertTrue(beforeRecordResponseCalled);
 }

--- a/YAHTTPVCR.podspec
+++ b/YAHTTPVCR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name     = 'YAHTTPVCR'
-    spec.version  = '1.3.0'
+    spec.version  = '1.3.1'
     spec.summary  = 'Yet Another HTTP VCR.'
     spec.homepage = 'https://github.com/parfeon/YAHTTPVCR'
     spec.documentation_url = 'https://github.com/parfeon/YAHTTPVCR/wiki'

--- a/YAHTTPVCR.xcodeproj/project.pbxproj
+++ b/YAHTTPVCR.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Integration)/Pods-Tests-[Test] iOS Code Coverage (Integration)-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Integration)/Pods-Tests-[Test] iOS Code Coverage (Integration)-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/YAHTTPVCR/YAHTTPVCR.framework",
 			);
@@ -570,7 +570,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Integration)/Pods-Tests-[Test] iOS Code Coverage (Integration)-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Integration)/Pods-Tests-[Test] iOS Code Coverage (Integration)-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1E8753A936B6BA649A41A054 /* [CP] Embed Pods Frameworks */ = {
@@ -579,7 +579,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Full)/Pods-Tests-[Test] iOS Code Coverage (Full)-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Full)/Pods-Tests-[Test] iOS Code Coverage (Full)-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/YAHTTPVCR/YAHTTPVCR.framework",
 			);
@@ -590,7 +590,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Full)/Pods-Tests-[Test] iOS Code Coverage (Full)-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Full)/Pods-Tests-[Test] iOS Code Coverage (Full)-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		432924DA5A64D428534EC5DE /* [CP] Check Pods Manifest.lock */ = {
@@ -671,7 +671,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Unit/Pods-Tests-[Test] iOS Unit-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Unit/Pods-Tests-[Test] iOS Unit-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/YAHTTPVCR/YAHTTPVCR.framework",
 			);
@@ -682,7 +682,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Unit/Pods-Tests-[Test] iOS Unit-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Unit/Pods-Tests-[Test] iOS Unit-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BB0AD9107D94B731AAC3B702 /* [CP] Embed Pods Frameworks */ = {
@@ -691,7 +691,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Unit)/Pods-Tests-[Test] iOS Code Coverage (Unit)-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Unit)/Pods-Tests-[Test] iOS Code Coverage (Unit)-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/YAHTTPVCR/YAHTTPVCR.framework",
 			);
@@ -702,7 +702,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Unit)/Pods-Tests-[Test] iOS Code Coverage (Unit)-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Code Coverage (Unit)/Pods-Tests-[Test] iOS Code Coverage (Unit)-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D851C0B07F25C7006F61AC3F /* [CP] Embed Pods Frameworks */ = {
@@ -711,7 +711,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Integration/Pods-Tests-[Test] iOS Integration-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Integration/Pods-Tests-[Test] iOS Integration-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/YAHTTPVCR/YAHTTPVCR.framework",
 			);
@@ -722,7 +722,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests-[Test] iOS Integration/Pods-Tests-[Test] iOS Integration-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tests-[Test] iOS Integration/Pods-Tests-[Test] iOS Integration-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/YAHTTPVCR/Core/YHVVCR+Player.h
+++ b/YAHTTPVCR/Core/YHVVCR+Player.h
@@ -9,6 +9,7 @@
 
 @class YHVNSURLProtocol;
 
+NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Interface declaration
 
@@ -83,3 +84,5 @@
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/YAHTTPVCR/Core/YHVVCR.h
+++ b/YAHTTPVCR/Core/YHVVCR.h
@@ -22,14 +22,19 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Information
 
 /**
- * @brief  Stores reference on cassette which currently inserted into VCR.
- */
-@property (class, nonatomic, readonly, strong) YHVCassette *cassette;
-
-/**
  * @brief  Stores reference on map of registered request matcher names to their GCD blocks.
  */
 @property (class, nonatomic, readonly, strong) NSDictionary<NSString *, YHVMatcherBlock> *matchers;
+
+/**
+ * @brief In case if query parameter represent list of elements, this option allow to sort it before trying to match.
+ */
+@property (class, nonatomic, assign) BOOL matchQueryWithSortedListValue;
+
+/**
+ * @brief  Stores reference on cassette which currently inserted into VCR.
+ */
+@property (class, nonatomic, readonly, strong) YHVCassette *cassette;
 
 
 #pragma mark - Configuration

--- a/YAHTTPVCR/Core/YHVVCR.m
+++ b/YAHTTPVCR/Core/YHVVCR.m
@@ -33,6 +33,13 @@ YHVMatchers YHVMatcher = {
     .headers = @"headers"
 };
 
+#pragma mark - Statics
+
+/**
+ * @brief Storage for 'matchQueryWithSortedListValue' class property
+ */
+static BOOL YHVMatchQueryWithSortedListValue = YES;
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -227,6 +234,16 @@ NS_ASSUME_NONNULL_END
 
 
 #pragma mark - Information
+
++ (BOOL)matchQueryWithSortedListValue {
+  
+  return YHVMatchQueryWithSortedListValue;
+}
+
++ (void)setMatchQueryWithSortedListValue:(BOOL)matchQueryWithSortedListValue {
+  
+  YHVMatchQueryWithSortedListValue = matchQueryWithSortedListValue;
+}
 
 + (YHVCassette *)cassette {
     
@@ -594,7 +611,8 @@ NS_ASSUME_NONNULL_END
         }
         
         if (configuration.queryParametersFilter) {
-            NSDictionary *query = [NSDictionary YHV_dictionaryWithQuery:finalRequest.URL.query];
+            NSDictionary *query = [NSDictionary YHV_dictionaryWithQuery:finalRequest.URL.query
+                                                   sortQueryListOnMatch:NO];
             NSMutableDictionary *mutableQuery = [query mutableCopy];
             
             ((YHVQueryParametersFilterBlock)configuration.queryParametersFilter)(request, mutableQuery);

--- a/YAHTTPVCR/Matchers/YHVRequestMatchers.m
+++ b/YAHTTPVCR/Matchers/YHVRequestMatchers.m
@@ -5,6 +5,7 @@
 #import "YHVRequestMatchers.h"
 #import "NSURLRequest+YHVPlayer.h"
 #import "NSDictionary+YHVNSURL.h"
+#import "YHVVCR.h"
 
 
 #define YHV_OUTPUT_MATCHING 0
@@ -102,8 +103,10 @@
 + (YHVMatcherBlock)query {
     
     return ^BOOL (NSURLRequest *request, NSURLRequest *stubRequest) {
-        NSDictionary *requestQuery = [NSDictionary YHV_dictionaryWithQuery:request.URL.query];
-        NSDictionary *stubRequestQuery = [NSDictionary YHV_dictionaryWithQuery:stubRequest.URL.query];
+        NSDictionary *requestQuery = [NSDictionary YHV_dictionaryWithQuery:request.URL.query
+                                                      sortQueryListOnMatch:YHVVCR.matchQueryWithSortedListValue];
+        NSDictionary *stubRequestQuery = [NSDictionary YHV_dictionaryWithQuery:stubRequest.URL.query
+                                                          sortQueryListOnMatch:YHVVCR.matchQueryWithSortedListValue];
 #if YHV_OUTPUT_MATCHING
         NSData *requestQueryData = [NSJSONSerialization dataWithJSONObject:requestQuery options:(NSJSONWritingOptions)0 error:nil];
         NSData *stubRequestQueryData = [NSJSONSerialization dataWithJSONObject:stubRequestQuery options:(NSJSONWritingOptions)0 error:nil];
@@ -178,8 +181,10 @@
             NSString *postBodyString = [[NSString alloc] initWithData:request.YHV_HTTPBody encoding:NSUTF8StringEncoding];
             stubPostBodyString = [stubPostBodyString stringByReplacingOccurrencesOfString:@"+" withString:@" "];
             postBodyString = [postBodyString stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-            stubPostBody = [NSDictionary YHV_dictionaryWithQuery:stubPostBodyString];
-            postBody = [NSDictionary YHV_dictionaryWithQuery:postBodyString];
+            stubPostBody = [NSDictionary YHV_dictionaryWithQuery:stubPostBodyString
+                                            sortQueryListOnMatch:YHVVCR.matchQueryWithSortedListValue];
+            postBody = [NSDictionary YHV_dictionaryWithQuery:postBodyString
+                                        sortQueryListOnMatch:YHVVCR.matchQueryWithSortedListValue];
         }
         
 #if YHV_OUTPUT_MATCHING

--- a/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURL.h
+++ b/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURL.h
@@ -18,10 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief  Create dictionary which contain key/value pairs from NSRUL query part.
  *
  * @param urlQuery Reference on \a NSURL's query string which should be parsed.
+ * @param sortOnMatch If query value is list, whether it should be sorted for match or not.
  *
  * @return Dictionary with keys and values extracted from NSURL query part.
  */
-+ (instancetype)YHV_dictionaryWithQuery:(NSString *)urlQuery;
++ (instancetype)YHV_dictionaryWithQuery:(NSString *)urlQuery sortQueryListOnMatch:(BOOL)sortOnMatch;
 
 /**
  * @brief      Encode data stored in dictionary to query string.

--- a/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURL.m
+++ b/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURL.m
@@ -12,7 +12,7 @@
 
 #pragma mark - NSURL
 
-+ (instancetype)YHV_dictionaryWithQuery:(NSString *)urlQuery {
++ (instancetype)YHV_dictionaryWithQuery:(NSString *)urlQuery sortQueryListOnMatch:(BOOL)sortOnMatch {
     
     NSMutableDictionary *dictionary = [NSMutableDictionary new];
     NSArray<NSString *> *keyValuePairsList = [urlQuery componentsSeparatedByString:@"&"];
@@ -37,6 +37,12 @@
         
         if (!error && object) {
             value = object;
+        } else if (sortOnMatch && [value isKindOfClass:[NSString class]] &&
+                   [(NSString *)value rangeOfString:@","].location != NSNotFound) {
+          
+          NSArray *listElements = [(NSString *)value componentsSeparatedByString:@","];
+          listElements = [listElements sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+          value = [listElements componentsJoinedByString:@","];
         }
         
         dictionary[key] = value;

--- a/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURLRequest.m
+++ b/YAHTTPVCR/Misc/Categories/NSDictionary+YHVNSURLRequest.m
@@ -81,7 +81,7 @@
     } else if ([contentType rangeOfString:@"application/x-www-form-urlencoded"].location != NSNotFound) {
         NSString *postBodyString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         postBodyString = [postBodyString stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-        dictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString];
+        dictionary = [NSDictionary YHV_dictionaryWithQuery:postBodyString sortQueryListOnMatch:NO];
     }
     
     return dictionary.count ? dictionary : nil;

--- a/YAHTTPVCR/Misc/YHVStructures.h
+++ b/YAHTTPVCR/Misc/YHVStructures.h
@@ -8,6 +8,8 @@
 #define YHVStructures_h
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 #pragma mark Types and Structures
 
 /**
@@ -139,7 +141,7 @@ typedef BOOL (^YHVHostFilterBlock)(NSString *host);
  *
  * @return Reference on string which should be used instead of exsiting URI path for \c request.
  */
-typedef NSString * (^YHVPathFilterBlock)(NSURLRequest *request);
+typedef NSString * __nonnull (^YHVPathFilterBlock)(NSURLRequest *request);
 
 /**
  * @brief      Request query parameters filter block.
@@ -180,7 +182,9 @@ typedef NSData * __nullable (^YHVPostBodyFilterBlock)(NSURLRequest *request, NSD
  *
  * @return Reference on value which should be used instead of original one or \c nil in case if response body should be removed.
  */
-typedef NSData * __nullable (^YHVResponseBodyFilterBlock)(NSURLRequest *request, NSHTTPURLResponse *response, NSData * __nullable data);
+typedef NSData * __nullable (^YHVResponseBodyFilterBlock)(NSURLRequest *request,
+                                                          NSHTTPURLResponse *response,
+                                                          NSData * __nullable data);
 
 /**
  * @brief      Requests match block.
@@ -216,6 +220,10 @@ typedef NSURLRequest * __nullable (^YHVBeforeRecordRequestBlock)(NSURLRequest *r
  * @return List (tuple) where first element is modified (same) \c response and second element modified (same) response \c data. Pass array only
  *         with \c response to remove \c data from stub.
  */
-typedef NSArray * (^YHVBeforeRecordResponseBlock)(NSURLRequest *request, NSHTTPURLResponse *response, NSData *data);
+typedef NSArray * __nonnull (^YHVBeforeRecordResponseBlock)(NSURLRequest *request,
+                                                            NSHTTPURLResponse *response,
+                                                            NSData * __nullable data);
 
 #endif // YHVStructures_h
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Fix comparison of value, which represent list by sorting.
Whether sorting should be done or not configurable by `YHVVCR.matchQueryWithSortedListValue`
flag which set to **YES** by default.